### PR TITLE
Switch from lazy.nvim to Neovim's built-in vim.pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 fish/completions/
 fish/fish_variables
 fish/conf.d/hydro.fish
+
+# vim.pack's generated lockfile (machine-specific resolved revisions)
+nvim/nvim-pack-lock.json

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -1,69 +1,33 @@
-local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-
-if not vim.loop.fs_stat(lazypath) then
-    vim.fn.system({
-        "git",
-        "clone",
-        "--filter=blob:none",
-        "https://github.com/folke/lazy.nvim.git",
-        "--branch=stable",
-        lazypath,
-    })
-end
-vim.opt.rtp:prepend(lazypath)
-
-require("lazy").setup({
-    {
-        'nvim-telescope/telescope.nvim',
-        tag = '0.1.8',
-        dependencies = { 'nvim-lua/plenary.nvim' }
-    },
-    {
-        "folke/tokyonight.nvim",
-        lazy = false,
-        priority = 1000,
-        opts = {},
-        config = function()
-            vim.cmd("colorscheme tokyonight-night")
-        end
-    },
-    { "nvim-treesitter/nvim-treesitter", build = ":TSUpdate" },
-    { "numToStr/Comment.nvim" },
-    {
-        "nvim-treesitter/nvim-treesitter-textobjects",
-        dependencies = "nvim-treesitter/nvim-treesitter",
-    },
-    { "NeogitOrg/neogit" , dependencies = {"sindrets/diffview.nvim"} },
-    { "lewis6991/gitsigns.nvim" },
-    {
-        'saghen/blink.cmp',
-        dependencies = { 'rafamadriz/friendly-snippets' }, -- Optional remove if not needed
-        -- use a release tag to download pre-built binaries
-        version = '1.*',
-        opts_extend = { "sources.default" }
-    },
-    { 'neovim/nvim-lspconfig', },
-    { 'nvim-tree/nvim-web-devicons', lazy = true },
-    {
-        "aserowy/tmux.nvim",
-        config = function() return require("tmux").setup({ copy_sync = { enable = false } }) end
-    },
-    {
-        'dhruvasagar/vim-table-mode',
-        lazy = true,
-        event = "BufReadPre *.md"
-    },
-    { "lukas-reineke/indent-blankline.nvim", main = "ibl" },
-    -- { "github/copilot.vim" },
-    {
-        "kylechui/nvim-surround",
-        version = "^3.0.0",
-        event = "VeryLazy",
-        config = function()
-            require("nvim-surround").setup({
-                -- Configuration here, or leave empty to use defaults
-            })
-        end
-    },
+vim.pack.add({
+    { src = "https://github.com/nvim-lua/plenary.nvim" },
+    { src = "https://github.com/nvim-telescope/telescope.nvim", version = "0.1.8" },
+    { src = "https://github.com/folke/tokyonight.nvim" },
+    -- pinned to `master`: `main` is treesitter's rewritten core-API branch,
+    -- which drops the `nvim-treesitter.configs` module this config uses
+    { src = "https://github.com/nvim-treesitter/nvim-treesitter", version = "master" },
+    { src = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects", version = "master" },
+    { src = "https://github.com/numToStr/Comment.nvim" },
+    { src = "https://github.com/sindrets/diffview.nvim" },
+    { src = "https://github.com/NeogitOrg/neogit" },
+    { src = "https://github.com/lewis6991/gitsigns.nvim" },
+    { src = "https://github.com/rafamadriz/friendly-snippets" },
+    { src = "https://github.com/saghen/blink.cmp", version = "v1.10.2" },
+    { src = "https://github.com/neovim/nvim-lspconfig" },
+    { src = "https://github.com/nvim-tree/nvim-web-devicons" },
+    { src = "https://github.com/aserowy/tmux.nvim" },
+    { src = "https://github.com/dhruvasagar/vim-table-mode" },
+    { src = "https://github.com/lukas-reineke/indent-blankline.nvim" },
+    { src = "https://github.com/kylechui/nvim-surround", version = "v3.1.8" },
 })
 
+vim.cmd.colorscheme("tokyonight-night")
+
+require("tmux").setup({ copy_sync = { enable = false } })
+
+require("nvim-surround").setup({
+    -- Configuration here, or leave empty to use defaults
+})
+
+-- nvim-treesitter no longer auto-updates parsers on plugin update (that was
+-- lazy.nvim's `build = ":TSUpdate"` hook). Run :TSUpdate by hand after
+-- `vim.pack.update()` touches this plugin.


### PR DESCRIPTION
Replaces lazy.nvim with Neovim 0.12+'s native `vim.pack`. Opening as draft for review before merging — I want to live with it for a bit first.

## What changed
- `nvim/lua/plugins.lua`: lazy.nvim bootstrap → `vim.pack.add()`. Config that lived in lazy specs (colorscheme, `tmux.nvim`/`nvim-surround` setup) now runs as plain calls after the `add()`.
- `.gitignore`: added `nvim/nvim-pack-lock.json` (vim.pack's generated lockfile).

## Requires Neovim 0.12+
`vim.pack` doesn't exist before 0.12. Upgrade first (`brew upgrade neovim`).

## Things worth a second look
- **nvim-treesitter is pinned to its `master` branch.** The default `main` branch is a rewrite that drops the `nvim-treesitter.configs` module `after/plugin/treesitter.lua` uses — without this pin, treesitter setup breaks outright. Same pin applied to `nvim-treesitter-textobjects`.
- **Version ranges became exact pins.** `vim.pack` doesn't resolve semver ranges like lazy.nvim did. `nvim-surround`'s `^3.0.0` → `v3.1.8` (latest 3.x tag; upstream has since moved to v4.x, not pulled in here). `blink.cmp`'s `1.*` → `v1.10.2`.
- **Lazy-loading is gone.** `nvim-web-devicons`, `vim-table-mode` (was event-loaded on markdown buffers), and `nvim-surround` (was `VeryLazy`) now load eagerly at startup — `vim.pack` has no event-based lazy loading. Minor startup-time cost, no functional loss expected.
- **The `:TSUpdate` build hook is gone.** Run it by hand after `vim.pack.update()` touches nvim-treesitter.

## Testing
Ran a clean headless Neovim startup against isolated `XDG_*_HOME` dirs: all 17 plugins install, colorscheme applies, and `telescope`/`nvim-surround`/`blink.cmp` all `require()` successfully. Not yet tested in daily use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)